### PR TITLE
Change Vortex 1.1.16 mutex API to be downward compatible t…

### DIFF
--- a/src/vortex_types.h
+++ b/src/vortex_types.h
@@ -921,7 +921,7 @@ typedef struct _VortexWin32Mutex {
 } VortexWin32Mutex;
 
 #define __OS_THREAD_TYPE__ win32_thread_t
-#define __OS_MUTEX_TYPE__  VortexWin32Mutex
+#define __OS_MUTEX_TYPE__  HANDLE
 #define __OS_COND_TYPE__   win32_cond_t
 
 typedef struct _win32_thread_t {


### PR DESCRIPTION
Since Vortex 1.1.16 there is a new feature for mutex handling to be able to differentiate between recursive and non-recursive mutexes and how they are unlocked.
In case of the Windows based implementation the mutex API parameter is a reference to a structure named "VortexWin32Mutex" defined in vortex_types.h.
In older Vortex releases it is a reference to a HANDLE.
Using the Vortex 1.1.16 library with an application / library compiled against an older Vortex release this produces stack violation errors.

With this changes the mutex API parameter is a reference to a HANDLE again.
Internally It is mapped to a "VortexWin32Mutex" structure allocated in  vortex_mutex_create_full() and freed in vortex_mutex_destroy().
