### PR TITLE
Add API "vortex_tls_get_ssl_digest" to Export Definition File

### DIFF
--- a/tls/libvortex-tls-1.1.def
+++ b/tls/libvortex-tls-1.1.def
@@ -7,6 +7,7 @@ vortex_tls_default_certificate
 vortex_tls_default_private_key
 vortex_tls_get_digest
 vortex_tls_get_digest_sized
+vortex_tls_get_ssl_digest
 vortex_tls_get_peer_ssl_digest
 vortex_tls_get_ssl_object
 vortex_tls_init


### PR DESCRIPTION
The new implemented API  "vortex_tls_get_ssl_digest" has to be added to the Export Definition File to become visible as an external on a MS Visual Studio link.
