### PR TITLE
Fixing the client and server method for TLS 1.0.

### DIFF
--- a/tls/vortex_tls.c
+++ b/tls/vortex_tls.c
@@ -733,7 +733,7 @@ int      vortex_tls_invoke_tls_activation (VortexConnection * connection)
 #elif defined(VORTEX_HAVE_TLSv11_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 		ssl_ctx  = SSL_CTX_new (TLSv1_1_client_method ());
 #elif defined(VORTEX_HAVE_TLSv10_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
-		ssl_ctx  = SSL_CTX_new (TLSv1_0_client_method ());
+		ssl_ctx  = SSL_CTX_new (TLSv1_client_method ());
 #elif defined(VORTEX_HAVE_SSLv3_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 		ssl_ctx  = SSL_CTX_new (SSLv3_client_method ());
 #else
@@ -1638,7 +1638,7 @@ void vortex_tls_prepare_listener (VortexConnection * connection)
 #elif defined(VORTEX_HAVE_TLSv11_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 		ssl_ctx  = SSL_CTX_new (TLSv1_1_server_method ());
 #elif defined(VORTEX_HAVE_TLSv10_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
-		ssl_ctx  = SSL_CTX_new (TLSv1_0_server_method ());
+		ssl_ctx  = SSL_CTX_new (TLSv1_server_method ());
 #elif defined(VORTEX_HAVE_SSLv3_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 		ssl_ctx  = SSL_CTX_new (SSLv3_server_method ());
 #else
@@ -2436,7 +2436,7 @@ char* vortex_tls_get_ssl_digest (const char * path, VortexDigestMethod   method)
 #elif defined(VORTEX_HAVE_TLSv11_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 	sslctx  = SSL_CTX_new (TLSv1_1_server_method ());
 #elif defined(VORTEX_HAVE_TLSv10_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
-	sslctx  = SSL_CTX_new (TLSv1_0_server_method ());
+	sslctx  = SSL_CTX_new (TLSv1_server_method ());
 #elif defined(VORTEX_HAVE_SSLv3_ENABLED) && OPENSSL_VERSION_NUMBER < 0x10100000L
 	sslctx  = SSL_CTX_new (SSLv3_server_method ());
 #else


### PR DESCRIPTION
The corresponding functions in OpenSSL are just prefixed with TLSv1
(missing the _0 that was present). This fixes a problem I had using
libvortex on OpenSSL 1.0.